### PR TITLE
feat: add retry backoff for connection errors in retryOperation

### DIFF
--- a/API-INTERNAL.md
+++ b/API-INTERNAL.md
@@ -145,6 +145,9 @@ that this internal function allows passing an additional <code>mergeReplaceNullP
 Any existing collection members not included in the new data will not be removed.
 Retries on failure.</p>
 </dd>
+<dt><a href="#getCallbackToStateMapping">getCallbackToStateMapping()</a></dt>
+<dd><p>Getter - returns the callback to state mapping, useful in test environments.</p>
+</dd>
 <dt><a href="#clearOnyxUtilsInternals">clearOnyxUtilsInternals()</a></dt>
 <dd><p>Clear internal variables used in this file, useful in test environments.</p>
 </dd>
@@ -519,6 +522,12 @@ Retries on failure.
 | params.collection | Object collection keyed by individual collection member keys and values |
 | retryAttempt | retry attempt |
 
+<a name="getCallbackToStateMapping"></a>
+
+## getCallbackToStateMapping()
+Getter - returns the callback to state mapping, useful in test environments.
+
+**Kind**: global function  
 <a name="clearOnyxUtilsInternals"></a>
 
 ## clearOnyxUtilsInternals()

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -838,8 +838,15 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
     }
 
     if (!isStorageCapacityError) {
+        const delay = getRetryDelay(currentRetryAttempt);
+        const isConnectionError = CONNECTION_ERRORS.some((connError) => errorName?.includes(connError) || errorMessage?.includes(connError));
+
+        if (isConnectionError) {
+            Logger.logInfo(`Connection error detected, retrying with backoff (${delay}ms). Error: ${error}. onyxMethod: ${onyxMethod.name}. retryAttempt: ${nextRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}`);
+        }
+
         // @ts-expect-error No overload matches this call.
-        return onyxMethod(defaultParams, nextRetryAttempt);
+        return wait(delay).then(() => onyxMethod(defaultParams, nextRetryAttempt));
     }
 
     // Find the least recently accessed evictable key that we can remove

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -765,13 +765,13 @@ function remove<TKey extends OnyxKey>(key: TKey, isProcessingCollectionUpdate?: 
     return Storage.removeItem(key).then(() => undefined);
 }
 
-function reportStorageQuota(): Promise<void> {
+function reportStorageQuota(error?: Error): Promise<void> {
     return Storage.getDatabaseSize()
         .then(({bytesUsed, bytesRemaining}) => {
-            Logger.logInfo(`Storage Quota Check -- bytesUsed: ${bytesUsed} bytesRemaining: ${bytesRemaining}`);
+            Logger.logInfo(`Storage Quota Check -- bytesUsed: ${bytesUsed} bytesRemaining: ${bytesRemaining}. Original error: ${error}`);
         })
         .catch((dbSizeError) => {
-            Logger.logAlert(`Unable to get database size. Error: ${dbSizeError}`);
+            Logger.logAlert(`Unable to get database size. Original error: ${error}. getDatabaseSize error: ${dbSizeError}`);
         });
 }
 
@@ -788,7 +788,7 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
     Logger.logInfo(`Failed to save to storage. Error: ${error}. onyxMethod: ${onyxMethod.name}. retryAttempt: ${currentRetryAttempt}/${MAX_STORAGE_OPERATION_RETRY_ATTEMPTS}`);
 
     if (error && Str.startsWith(error.message, "Failed to execute 'put' on 'IDBObjectStore'")) {
-        Logger.logAlert('Attempted to set invalid data set in Onyx. Please ensure all data is serializable.');
+        Logger.logAlert(`Attempted to set invalid data set in Onyx. Please ensure all data is serializable. Error: ${error}`);
         throw error;
     }
 
@@ -812,13 +812,13 @@ function retryOperation<TMethod extends RetriableOnyxOperation>(error: Error, on
         // If we have no acceptable keys to remove then we are possibly trying to save mission critical data. If this is the case,
         // then we should stop retrying as there is not much the user can do to fix this. Instead of getting them stuck in an infinite loop we
         // will allow this write to be skipped.
-        Logger.logAlert('Out of storage. But found no acceptable keys to remove.');
-        return reportStorageQuota();
+        Logger.logAlert(`Out of storage. But found no acceptable keys to remove. Error: ${error}`);
+        return reportStorageQuota(error);
     }
 
     // Remove the least recently accessed key and retry.
-    Logger.logInfo(`Out of storage. Evicting least recently accessed key (${keyForRemoval}) and retrying.`);
-    reportStorageQuota();
+    Logger.logInfo(`Out of storage. Evicting least recently accessed key (${keyForRemoval}) and retrying. Error: ${error}`);
+    reportStorageQuota(error);
 
     // @ts-expect-error No overload matches this call.
     return remove(keyForRemoval).then(() => onyxMethod(defaultParams, nextRetryAttempt));

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -771,7 +771,7 @@ function reportStorageQuota(error?: Error): Promise<void> {
             Logger.logInfo(`Storage Quota Check -- bytesUsed: ${bytesUsed} bytesRemaining: ${bytesRemaining}. Original error: ${error}`);
         })
         .catch((dbSizeError) => {
-            Logger.logAlert(`Unable to get database size. Original error: ${error}. getDatabaseSize error: ${dbSizeError}`);
+            Logger.logAlert(`Unable to get database size. getDatabaseSize error: ${dbSizeError}. Original error: ${error}`);
         });
 }
 

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -64,6 +64,24 @@ const STORAGE_ERRORS = [...IDB_STORAGE_ERRORS, ...SQLITE_STORAGE_ERRORS];
 // Max number of retries for failed storage operations
 const MAX_STORAGE_OPERATION_RETRY_ATTEMPTS = 5;
 
+// Connection/state errors where the DB needs time to recover — backoff helps, eviction does not
+const IDB_CONNECTION_ERRORS = [
+    'internal error opening backing store', // Chrome/Edge: corrupted IDB state
+    'connection to indexed database server lost', // Safari: IDB connection dropped
+    'the database connection is closing', // Cross-browser: DB closing during write
+] as const;
+
+const SQLITE_CONNECTION_ERRORS = [
+    'disk i/o error', // Native: filesystem/device stress
+    'database is locked', // Native: concurrent access contention
+] as const;
+
+const CONNECTION_ERRORS = [...IDB_CONNECTION_ERRORS, ...SQLITE_CONNECTION_ERRORS];
+
+// Retry backoff configuration
+const RETRY_BASE_DELAY_MS = 100;
+const RETRY_JITTER_FACTOR = 0.25;
+
 type OnyxMethod = ValueOf<typeof METHOD>;
 
 // Key/value store of Onyx key and arrays of values to merge
@@ -761,6 +779,26 @@ function remove<TKey extends OnyxKey>(key: TKey, isProcessingCollectionUpdate?: 
     }
 
     return Storage.removeItem(key).then(() => undefined);
+}
+
+/**
+ * Returns a promise that resolves after the given number of milliseconds.
+ */
+function wait(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+/**
+ * Calculates exponential backoff delay with jitter for a given retry attempt.
+ * Formula: baseDelay * 2^attempt ± jitter
+ * Attempt 0: ~100ms, Attempt 1: ~200ms, ..., Attempt 4: ~1600ms
+ */
+function getRetryDelay(attempt: number): number {
+    const baseDelay = RETRY_BASE_DELAY_MS * 2 ** attempt;
+    const jitter = baseDelay * RETRY_JITTER_FACTOR * (2 * Math.random() - 1);
+    return Math.round(baseDelay + jitter);
 }
 
 function reportStorageQuota(error?: Error): Promise<void> {

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -798,7 +798,7 @@ function wait(ms: number): Promise<void> {
 function getRetryDelay(attempt: number): number {
     const baseDelay = RETRY_BASE_DELAY_MS * 2 ** attempt;
     const jitter = baseDelay * RETRY_JITTER_FACTOR * (2 * Math.random() - 1);
-    return Math.round(baseDelay + jitter);
+    return Math.max(0, Math.round(baseDelay + jitter));
 }
 
 function reportStorageQuota(error?: Error): Promise<void> {

--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1055,6 +1055,24 @@ function subscribeToKey<TKey extends OnyxKey>(connectOptions: ConnectOptions<TKe
     callbackToStateMapping[subscriptionID] = mapping as CallbackToStateMapping<OnyxKey>;
     callbackToStateMapping[subscriptionID].subscriptionID = subscriptionID;
 
+    // If the subscriber is attempting to connect to a collection member whose ID is skippable (e.g. "undefined", "null", etc.)
+    // we suppress wiring the subscription fully to avoid unnecessary callback emissions such as for "report_undefined".
+    // We still return a valid subscriptionID so callers can disconnect safely.
+    try {
+        const skippableIDs = getSkippableCollectionMemberIDs();
+        if (skippableIDs.size) {
+            const [, collectionMemberID] = OnyxKeys.splitCollectionMemberKey(mapping.key);
+            if (skippableIDs.has(collectionMemberID)) {
+                // Clean up the provisional mapping to avoid retaining unused subscribers.
+                cache.addNullishStorageKey(mapping.key);
+                delete callbackToStateMapping[subscriptionID];
+                return subscriptionID;
+            }
+        }
+    } catch (e) {
+        // Not a collection member key, proceed as usual.
+    }
+
     // When keyChanged is called, a key is passed and the method looks through all the Subscribers in callbackToStateMapping for the matching key to get the subscriptionID
     // to avoid having to loop through all the Subscribers all the time (even when just one connection belongs to one key),
     // We create a mapping from key to lists of subscriptionIDs to access the specific list of subscriptionIDs.
@@ -1662,6 +1680,13 @@ function logKeyRemoved(onyxMethod: Extract<OnyxMethod, 'set' | 'merge'>, key: On
 }
 
 /**
+ * Getter - returns the callback to state mapping, useful in test environments.
+ */
+function getCallbackToStateMapping(): Record<number, CallbackToStateMapping<OnyxKey>> {
+    return callbackToStateMapping;
+}
+
+/**
  * Clear internal variables used in this file, useful in test environments.
  */
 function clearOnyxUtilsInternals() {
@@ -1720,6 +1745,7 @@ const OnyxUtils = {
     setWithRetry,
     multiSetWithRetry,
     setCollectionWithRetry,
+    getCallbackToStateMapping,
 };
 
 export type {OnyxMethod};

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-onyx",
-  "version": "3.0.66",
+  "version": "3.0.67",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-onyx",
-      "version": "3.0.66",
+      "version": "3.0.67",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-onyx",
-  "version": "3.0.67",
+  "version": "3.0.68",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-onyx",
-      "version": "3.0.67",
+      "version": "3.0.68",
       "license": "MIT",
       "dependencies": {
         "ascii-table": "0.0.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onyx",
-  "version": "3.0.67",
+  "version": "3.0.68",
   "author": "Expensify, Inc.",
   "homepage": "https://expensify.com",
   "description": "State management for React Native",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-onyx",
-  "version": "3.0.66",
+  "version": "3.0.67",
   "author": "Expensify, Inc.",
   "homepage": "https://expensify.com",
   "description": "State management for React Native",

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -424,7 +424,7 @@ describe('OnyxUtils', () => {
 
             await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
 
-            expect(logAlertSpy).toHaveBeenCalledWith(`Unable to get database size. Original error: ${memoryError}. getDatabaseSize error: ${dbSizeError}`);
+            expect(logAlertSpy).toHaveBeenCalledWith(`Unable to get database size. getDatabaseSize error: ${dbSizeError}. Original error: ${memoryError}`);
         });
 
         it('should not re-add an evicted key to recentlyAccessedKeys after removal', async () => {

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -408,23 +408,23 @@ describe('OnyxUtils', () => {
         it('should include the error in logs when out of storage with no evictable keys', async () => {
             const logAlertSpy = jest.spyOn(Logger, 'logAlert');
             const logInfoSpy = jest.spyOn(Logger, 'logInfo');
-            StorageMock.setItem = jest.fn().mockRejectedValue(memoryError);
+            StorageMock.setItem = jest.fn().mockRejectedValue(diskFullError);
 
             await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
 
-            expect(logAlertSpy).toHaveBeenCalledWith(`Out of storage. But found no acceptable keys to remove. Error: ${memoryError}`);
-            expect(logInfoSpy).toHaveBeenCalledWith(`Storage Quota Check -- bytesUsed: 0 bytesRemaining: Infinity. Original error: ${memoryError}`);
+            expect(logAlertSpy).toHaveBeenCalledWith(`Out of storage. But found no acceptable keys to remove. Error: ${diskFullError}`);
+            expect(logInfoSpy).toHaveBeenCalledWith(`Storage Quota Check -- bytesUsed: 0 bytesRemaining: Infinity. Original error: ${diskFullError}`);
         });
 
         it('should include the error in logAlert when out of storage and getDatabaseSize fails', async () => {
             const dbSizeError = new Error('Failed to estimate storage');
             const logAlertSpy = jest.spyOn(Logger, 'logAlert');
-            StorageMock.setItem = jest.fn().mockRejectedValue(memoryError);
+            StorageMock.setItem = jest.fn().mockRejectedValue(diskFullError);
             StorageMock.getDatabaseSize = jest.fn().mockRejectedValue(dbSizeError);
 
             await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
 
-            expect(logAlertSpy).toHaveBeenCalledWith(`Unable to get database size. getDatabaseSize error: ${dbSizeError}. Original error: ${memoryError}`);
+            expect(logAlertSpy).toHaveBeenCalledWith(`Unable to get database size. getDatabaseSize error: ${dbSizeError}. Original error: ${diskFullError}`);
         });
 
         it('should not re-add an evicted key to recentlyAccessedKeys after removal', async () => {

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -6,6 +6,7 @@ import utils from '../../lib/utils';
 import type {Collection, OnyxCollection} from '../../lib/types';
 import type GenericCollection from '../utils/GenericCollection';
 import OnyxCache from '../../lib/OnyxCache';
+import * as Logger from '../../lib/Logger';
 import StorageMock from '../../lib/storage';
 import createDeferredTask from '../../lib/createDeferredTask';
 import waitForPromisesToResolve from '../utils/waitForPromisesToResolve';
@@ -395,6 +396,26 @@ describe('OnyxUtils', () => {
             expect(retryOperationSpy).toHaveBeenCalledTimes(1);
         });
 
+        it('should include the error in logAlert for IDBObjectStore invalid data errors', async () => {
+            const logAlertSpy = jest.spyOn(Logger, 'logAlert');
+            StorageMock.setItem = jest.fn().mockRejectedValueOnce(invalidDataError);
+
+            await expect(Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'})).rejects.toThrow(invalidDataError);
+
+            expect(logAlertSpy).toHaveBeenCalledWith(`Attempted to set invalid data set in Onyx. Please ensure all data is serializable. Error: ${invalidDataError}`);
+        });
+
+        it('should include the error in logs when out of storage with no evictable keys', async () => {
+            const logAlertSpy = jest.spyOn(Logger, 'logAlert');
+            const logInfoSpy = jest.spyOn(Logger, 'logInfo');
+            StorageMock.setItem = jest.fn().mockRejectedValue(memoryError);
+
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+
+            expect(logAlertSpy).toHaveBeenCalledWith(`Out of storage. But found no acceptable keys to remove. Error: ${memoryError}`);
+            expect(logInfoSpy).toHaveBeenCalledWith(`Storage Quota Check -- bytesUsed: 0 bytesRemaining: Infinity. Original error: ${memoryError}`);
+        });
+
         it('should not re-add an evicted key to recentlyAccessedKeys after removal', async () => {
             // Re-init with evictable keys so getKeyForEviction() has something to return
             Object.assign(OnyxUtils.getDeferredInitTask(), createDeferredTask());
@@ -422,6 +443,7 @@ describe('OnyxUtils', () => {
         let LocalOnyxUtils: typeof OnyxUtils;
         let LocalOnyxCache: typeof OnyxCache;
         let LocalStorageMock: typeof StorageMock;
+        let LocalLogger: typeof Logger;
 
         // Reset all modules to get fresh singletons (OnyxCache, OnyxUtils, etc.)
         // then re-init Onyx with evictableKeys configured
@@ -432,6 +454,7 @@ describe('OnyxUtils', () => {
             LocalOnyxUtils = require('../../lib/OnyxUtils').default;
             LocalOnyxCache = require('../../lib/OnyxCache').default;
             LocalStorageMock = require('../../lib/storage').default;
+            LocalLogger = require('../../lib/Logger');
 
             LocalOnyx.init({
                 keys: ONYXKEYS,
@@ -536,6 +559,20 @@ describe('OnyxUtils', () => {
             const keyForEviction = LocalOnyxCache.getKeyForEviction();
             expect(keyForEviction).toBeDefined();
             expect(keyForEviction?.startsWith(ONYXKEYS.COLLECTION.TEST_KEY)).toBe(true);
+        });
+
+        it('should include the error in logs when evicting a key', async () => {
+            const logInfoSpy = jest.spyOn(LocalLogger, 'logInfo');
+            const key1 = `${ONYXKEYS.COLLECTION.TEST_KEY}1`;
+
+            await LocalOnyx.set(key1, {id: 1});
+
+            LocalStorageMock.setItem = jest.fn(LocalStorageMock.setItem).mockRejectedValueOnce(diskFullError).mockImplementation(LocalStorageMock.setItem);
+
+            await LocalOnyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+
+            expect(logInfoSpy).toHaveBeenCalledWith(`Out of storage. Evicting least recently accessed key (${key1}) and retrying. Error: ${diskFullError}`);
+            expect(logInfoSpy).toHaveBeenCalledWith(`Storage Quota Check -- bytesUsed: 0 bytesRemaining: Infinity. Original error: ${diskFullError}`);
         });
     });
 

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -416,6 +416,17 @@ describe('OnyxUtils', () => {
             expect(logInfoSpy).toHaveBeenCalledWith(`Storage Quota Check -- bytesUsed: 0 bytesRemaining: Infinity. Original error: ${memoryError}`);
         });
 
+        it('should include the error in logAlert when out of storage and getDatabaseSize fails', async () => {
+            const dbSizeError = new Error('Failed to estimate storage');
+            const logAlertSpy = jest.spyOn(Logger, 'logAlert');
+            StorageMock.setItem = jest.fn().mockRejectedValue(memoryError);
+            StorageMock.getDatabaseSize = jest.fn().mockRejectedValue(dbSizeError);
+
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+
+            expect(logAlertSpy).toHaveBeenCalledWith(`Unable to get database size. Original error: ${memoryError}. getDatabaseSize error: ${dbSizeError}`);
+        });
+
         it('should not re-add an evicted key to recentlyAccessedKeys after removal', async () => {
             // Re-init with evictable keys so getKeyForEviction() has something to return
             Object.assign(OnyxUtils.getDeferredInitTask(), createDeferredTask());

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -95,6 +95,74 @@ describe('OnyxUtils', () => {
 
     afterEach(() => jest.clearAllMocks());
 
+    describe('skippable member subscriptions', () => {
+        const BASE = ONYXKEYS.COLLECTION.TEST_KEY;
+
+        beforeEach(() => {
+            // Enable skipping of undefined member IDs for these tests
+            OnyxUtils.setSkippableCollectionMemberIDs(new Set(['undefined']));
+        });
+
+        afterEach(() => {
+            // Restore to no skippable IDs to avoid affecting other tests
+            OnyxUtils.setSkippableCollectionMemberIDs(new Set());
+        });
+
+        it('does not emit initial callback for report_undefined member', async () => {
+            const key = `${BASE}undefined`;
+            const callback = jest.fn();
+            Onyx.connect({key, callback});
+
+            // Flush async subscription flow
+            await act(async () => waitForPromisesToResolve());
+
+            // No initial data should be sent for a skippable member
+            expect(callback).not.toHaveBeenCalled();
+        });
+
+        it('still emits for valid member keys', async () => {
+            const key = `${BASE}123`;
+            await Onyx.set(key, {id: 123});
+
+            const callback = jest.fn();
+            Onyx.connect({key, callback});
+            await act(async () => waitForPromisesToResolve());
+            expect(callback).toHaveBeenCalledTimes(1);
+            expect(callback).toHaveBeenCalledWith({id: 123}, key);
+        });
+
+        it('omits skippable members from base collection', async () => {
+            const undefinedKey = `${BASE}undefined`;
+            const validKey = `${BASE}1`;
+
+            await Onyx.set(undefinedKey, {bad: true});
+            await Onyx.set(validKey, {ok: true});
+
+            let received: Record<string, unknown> | undefined;
+            Onyx.connect({
+                key: BASE,
+                waitForCollectionCallback: true,
+                callback: (value) => {
+                    received = value as Record<string, unknown>;
+                },
+            });
+            await act(async () => waitForPromisesToResolve());
+            expect(received).toEqual({[validKey]: {ok: true}});
+            expect(Object.keys(received ?? {})).not.toContain(undefinedKey);
+        });
+
+        it('does not register an active subscription in callbackToStateMapping for a skippable member', async () => {
+            const skippableKey = `${BASE}undefined`;
+            Onyx.connect({key: skippableKey, callback: jest.fn()});
+
+            await act(async () => waitForPromisesToResolve());
+
+            const mappings = OnyxUtils.getCallbackToStateMapping();
+            const hasActiveSubscription = Object.values(mappings).some((m) => m.key === skippableKey);
+            expect(hasActiveSubscription).toBe(false);
+        });
+    });
+
     describe('partialSetCollection', () => {
         beforeEach(() => {
             Onyx.clear();

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -432,21 +432,35 @@ describe('OnyxUtils', () => {
         const diskFullError = new Error('database or disk is full');
 
         it('should retry only one time if the operation is firstly failed and then passed', async () => {
-            StorageMock.setItem = jest.fn(StorageMock.setItem).mockRejectedValueOnce(genericError).mockImplementation(StorageMock.setItem);
+            jest.useFakeTimers();
+            try {
+                StorageMock.setItem = jest.fn(StorageMock.setItem).mockRejectedValueOnce(genericError).mockImplementation(StorageMock.setItem);
 
-            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
 
-            // Should be called once, since Storage.setItem if failed only once
-            expect(retryOperationSpy).toHaveBeenCalledTimes(1);
+                // Should be called once, since Storage.setItem failed only once
+                expect(retryOperationSpy).toHaveBeenCalledTimes(1);
+            } finally {
+                jest.useRealTimers();
+            }
         });
 
         it('should stop retrying after MAX_STORAGE_OPERATION_RETRY_ATTEMPTS retries for failing operation', async () => {
-            StorageMock.setItem = jest.fn().mockRejectedValue(genericError);
+            jest.useFakeTimers();
+            try {
+                StorageMock.setItem = jest.fn().mockRejectedValue(genericError);
 
-            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
 
-            // Should be called 6 times: initial attempt + 5 retries (MAX_STORAGE_OPERATION_RETRY_ATTEMPTS)
-            expect(retryOperationSpy).toHaveBeenCalledTimes(6);
+                // Should be called 6 times: initial attempt + 5 retries (MAX_STORAGE_OPERATION_RETRY_ATTEMPTS)
+                expect(retryOperationSpy).toHaveBeenCalledTimes(6);
+            } finally {
+                jest.useRealTimers();
+            }
         });
 
         it("should throw error for if operation failed with \"Failed to execute 'put' on 'IDBObjectStore': invalid data\" error", async () => {
@@ -511,6 +525,72 @@ describe('OnyxUtils', () => {
 
             await OnyxUtils.remove(evictableKey);
             expect(OnyxCache.getKeyForEviction()).toBeUndefined();
+        });
+
+        it('should apply exponential backoff delay for non-capacity errors', async () => {
+            jest.useFakeTimers();
+            try {
+                const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+                StorageMock.setItem = jest.fn().mockRejectedValue(genericError);
+
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
+
+                // Filter setTimeout calls to only those from our wait() helper (delay > 0)
+                const backoffDelays = setTimeoutSpy.mock.calls
+                    .map((call) => call[1])
+                    .filter((delay): delay is number => typeof delay === 'number' && delay > 0);
+
+                // Should have 5 backoff delays (one before each of the 5 retries, attempts 0-4)
+                // The 6th call to retryOperation (attempt 5) hits the MAX check and resolves without waiting
+                expect(backoffDelays).toHaveLength(5);
+
+                // Verify exponential growth pattern: each delay should be roughly double the previous
+                // With ±25% jitter, delay[n+1] / delay[n] should be between ~1.2 and ~3.3
+                for (let i = 1; i < backoffDelays.length; i++) {
+                    const ratio = backoffDelays[i] / backoffDelays[i - 1];
+                    expect(ratio).toBeGreaterThan(1.0);
+                    expect(ratio).toBeLessThan(4.0);
+                }
+
+                setTimeoutSpy.mockRestore();
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('should log connection error with backoff delay info', async () => {
+            jest.useFakeTimers();
+            try {
+                const logInfoSpy = jest.spyOn(Logger, 'logInfo');
+                const connectionError = new Error('Connection to Indexed Database server lost. Refresh the page to try again');
+                StorageMock.setItem = jest.fn(StorageMock.setItem).mockRejectedValueOnce(connectionError).mockImplementation(StorageMock.setItem);
+
+                const setPromise = Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+                await jest.runAllTimersAsync();
+                await setPromise;
+
+                expect(logInfoSpy).toHaveBeenCalledWith(expect.stringContaining('Connection error detected, retrying with backoff'));
+                expect(logInfoSpy).toHaveBeenCalledWith(expect.stringContaining('Connection to Indexed Database server lost'));
+            } finally {
+                jest.useRealTimers();
+            }
+        });
+
+        it('should NOT apply backoff delay for capacity errors (immediate retry with eviction)', async () => {
+            const setTimeoutSpy = jest.spyOn(global, 'setTimeout');
+            StorageMock.setItem = jest.fn().mockRejectedValue(diskFullError);
+
+            await Onyx.set(ONYXKEYS.TEST_KEY, {test: 'data'});
+
+            // Capacity errors should not trigger any backoff delays (delay > 0)
+            const backoffDelays = setTimeoutSpy.mock.calls
+                .map((call) => call[1])
+                .filter((delay): delay is number => typeof delay === 'number' && delay > 0);
+
+            expect(backoffDelays).toHaveLength(0);
+            setTimeoutSpy.mockRestore();
         });
     });
 

--- a/tests/unit/useOnyxTest.ts
+++ b/tests/unit/useOnyxTest.ts
@@ -1110,6 +1110,54 @@ describe('useOnyx', () => {
             expect(result.current[0]).toBeUndefined();
             expect(result.current[1].status).toEqual('loaded');
         });
+
+        it('should return undefined and loaded state when switching from a valid key to a skippable one', async () => {
+            await Onyx.set(`${ONYXKEYS.COLLECTION.TEST_KEY}1`, {id: '1'});
+            // Seed a value directly in storage for the skippable key.
+            // If the subscription is NOT skipped, Onyx would load this and return it.
+            // Asserting undefined below proves the subscription was actually suppressed.
+            await StorageMock.setItem(`${ONYXKEYS.COLLECTION.TEST_KEY}skippable-id`, {id: 'skippable'});
+
+            const {result, rerender} = renderHook((key: string) => useOnyx(key), {initialProps: `${ONYXKEYS.COLLECTION.TEST_KEY}1` as string});
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toEqual({id: '1'});
+            expect(result.current[1].status).toEqual('loaded');
+
+            await act(async () => {
+                rerender(`${ONYXKEYS.COLLECTION.TEST_KEY}skippable-id`);
+            });
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toBeUndefined();
+            expect(result.current[1].status).toEqual('loaded');
+        });
+
+        it('should transition through loading and return value when switching from a skippable key to a valid one', async () => {
+            // Seed a value for the skippable key — must stay invisible to the hook
+            await StorageMock.setItem(`${ONYXKEYS.COLLECTION.TEST_KEY}skippable-id`, {id: 'skippable'});
+            // Seed the target valid key in storage only (not in cache) so the switch goes through loading
+            await StorageMock.setItem(`${ONYXKEYS.COLLECTION.TEST_KEY}1`, {id: '1'});
+
+            const {result, rerender} = renderHook((key: string) => useOnyx(key), {initialProps: `${ONYXKEYS.COLLECTION.TEST_KEY}skippable-id` as string});
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toBeUndefined();
+            expect(result.current[1].status).toEqual('loaded');
+
+            // Switch to a valid key whose value is in storage but not in cache — should transition through loading
+            rerender(`${ONYXKEYS.COLLECTION.TEST_KEY}1`);
+
+            expect(result.current[1].status).toEqual('loading');
+
+            await act(async () => waitForPromisesToResolve());
+
+            expect(result.current[0]).toEqual({id: '1'});
+            expect(result.current[1].status).toEqual('loaded');
+        });
     });
 
     describe('RAM-only keys', () => {


### PR DESCRIPTION
## Summary

- Add exponential backoff with jitter to `OnyxUtils.retryOperation` for non-capacity storage errors
- Connection-class errors (#1, #3, #5 from [storage error investigation](https://github.com/Expensify/App/issues/85252#issuecomment-4224034362)) account for 51.7% of all failures — immediate retry was ineffective, DB needs recovery time
- Backoff schedule: `100ms → 200ms → 400ms → 800ms → 1600ms` (±25% jitter), capacity errors keep immediate retry with eviction

## Linked Issues

- Upstream: https://github.com/Expensify/App/issues/87782
- Parent: https://github.com/Expensify/App/issues/85252

## Changes

- `lib/OnyxUtils.ts`: `CONNECTION_ERRORS` constants, `wait()`/`getRetryDelay()` helpers, backoff wired into non-capacity error branch of `retryOperation`
- `tests/unit/onyxUtilsTest.ts`: Updated 2 existing tests for fake timers, added 3 new tests (exponential progression, connection error logging, capacity errors remain immediate)

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes
- [ ] `npm test` — 437/437 tests pass
- [ ] Verify backoff delays increase exponentially (test: `should apply exponential backoff delay for non-capacity errors`)
- [ ] Verify connection errors log with backoff info (test: `should log connection error with backoff delay info`)
- [ ] Verify capacity errors are NOT delayed (test: `should NOT apply backoff delay for capacity errors`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)