### PR TITLE
perf: batch cold-cache pre-warm in mergeCollectionWithPatches via mul…

### DIFF
--- a/lib/OnyxUtils.ts
+++ b/lib/OnyxUtils.ts
@@ -1582,12 +1582,20 @@ function mergeCollectionWithPatches<TKey extends CollectionKeyBase>(
             // finalMergedCollection contains all the keys that were merged, without the keys of incompatible updates
             const finalMergedCollection = {...existingKeyCollection, ...newCollection};
 
-            // Pre-warm cache for any existing storage keys that aren't yet in cache. get() is a no-op
-            // (sync-resolved) for cache hits, and on a cache miss it reads from storage and writes the
-            // value back to cache. This is required so the subsequent cache.merge() merges the new delta
-            // into the real previous storage value (rather than starting from `undefined` and dropping
-            // the existing keys).
-            return Promise.all(existingKeys.map((key) => get(key))).then(() => {
+            // Pre-warm cache for any existing storage keys that aren't yet in cache so the subsequent
+            // cache.merge() merges the new delta into the real previous storage value (rather than
+            // starting from `undefined` and dropping the existing keys).
+            //
+            // Fast path: when every existingKey is already in cache, skip the pre-warm entirely. This
+            // preserves the original promise-chain depth and the subscriber-callback timing that
+            // dependent tests rely on.
+            //
+            // Slow path: when at least one existingKey is a cache miss, use multiGet — it batches the
+            // missing keys into a single Storage.multiGet call (vs. N parallel get() invocations) and
+            // writes the storage values back to cache before resolving.
+            const hasColdExistingKey = existingKeys.some((key) => !cache.hasCacheForKey(key));
+            const prewarmPromise = hasColdExistingKey ? multiGet(existingKeys) : Promise.resolve();
+            return prewarmPromise.then(() => {
                 // Snapshot previous values from the (now-warm) cache for keysChanged's diff, then update
                 // cache and notify subscribers synchronously BEFORE issuing storage writes. This matches
                 // the cache-first / storage-second invariant followed by every other Onyx write method

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -158,7 +158,10 @@ describe('OnyxUtils', () => {
                 [routeA]: {name: 'Route A'},
             } as GenericCollection);
 
-            await OnyxUtils.partialSetCollection({collectionKey: ONYXKEYS.COLLECTION.ROUTES, collection: {} as GenericCollection});
+            await OnyxUtils.partialSetCollection({
+                collectionKey: ONYXKEYS.COLLECTION.ROUTES,
+                collection: {} as GenericCollection,
+            });
 
             expect(result).toEqual({
                 [routeA]: {name: 'Route A'},
@@ -230,9 +233,18 @@ describe('OnyxUtils', () => {
             const spy2 = jest.fn();
             const spy3 = jest.fn();
 
-            const conn1 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`, callback: spy1});
-            const conn2 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`, callback: spy2});
-            const conn3 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}3`, callback: spy3});
+            const conn1 = Onyx.connect({
+                key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`,
+                callback: spy1,
+            });
+            const conn2 = Onyx.connect({
+                key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`,
+                callback: spy2,
+            });
+            const conn3 = Onyx.connect({
+                key: `${ONYXKEYS.COLLECTION.TEST_KEY}3`,
+                callback: spy3,
+            });
             await waitForPromisesToResolve();
             spy1.mockClear();
             spy2.mockClear();
@@ -335,8 +347,14 @@ describe('OnyxUtils', () => {
 
             const spy1 = jest.fn();
             const spy2 = jest.fn();
-            const conn1 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`, callback: spy1});
-            const conn2 = Onyx.connect({key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`, callback: spy2});
+            const conn1 = Onyx.connect({
+                key: `${ONYXKEYS.COLLECTION.TEST_KEY}1`,
+                callback: spy1,
+            });
+            const conn2 = Onyx.connect({
+                key: `${ONYXKEYS.COLLECTION.TEST_KEY}2`,
+                callback: spy2,
+            });
             await waitForPromisesToResolve();
             spy1.mockClear();
             spy2.mockClear();
@@ -389,7 +407,10 @@ describe('OnyxUtils', () => {
             // A subscriber for keyA synchronously calls Onyx.set() on keyB during its callback.
             // After multiSet completes, the cache must reflect the multiSet's value for keyB
             // (multiSet wins), and the keyB subscriber's last seen value must equal the cache.
-            await Onyx.multiSet({[ONYXKEYS.TEST_KEY]: 'initialA', [ONYXKEYS.TEST_KEY_2]: 'initialB'});
+            await Onyx.multiSet({
+                [ONYXKEYS.TEST_KEY]: 'initialA',
+                [ONYXKEYS.TEST_KEY_2]: 'initialB',
+            });
 
             const callbackA = jest.fn((value: unknown) => {
                 if (value !== 'newA') {
@@ -613,8 +634,16 @@ describe('OnyxUtils', () => {
             const failingCallback = jest.fn();
             const workingCallback = jest.fn();
 
-            const connFailing = Onyx.connect({key: entryKey, callback: failingCallback, reuseConnection: false});
-            const connWorking = Onyx.connect({key: entryKey, callback: workingCallback, reuseConnection: false});
+            const connFailing = Onyx.connect({
+                key: entryKey,
+                callback: failingCallback,
+                reuseConnection: false,
+            });
+            const connWorking = Onyx.connect({
+                key: entryKey,
+                callback: workingCallback,
+                reuseConnection: false,
+            });
             await waitForPromisesToResolve();
             failingCallback.mockReset();
             failingCallback.mockImplementation(() => {
@@ -848,7 +877,9 @@ describe('OnyxUtils', () => {
             // Cache must reflect the merge regardless of the multiMerge rejection. This is the
             // cache-first / storage-second invariant that mergeCollectionWithPatches must honor.
             const cachedCollection = OnyxCache.getCollectionData(collectionKey);
-            expect(cachedCollection?.[existingMemberKey]).toEqual({value: 'merged'});
+            expect(cachedCollection?.[existingMemberKey]).toEqual({
+                value: 'merged',
+            });
             expect(cachedCollection?.[newMemberKey]).toEqual({value: 'new'});
 
             // Subscribers must have been notified with the merged values.
@@ -896,6 +927,176 @@ describe('OnyxUtils', () => {
             const lastBroadcast = collectionCallback.mock.calls.at(-1)?.[0] as Record<string, unknown> | undefined;
             expect(lastBroadcast?.[newMemberKey1]).toEqual({value: 'first'});
             expect(lastBroadcast?.[newMemberKey2]).toEqual({value: 'second'});
+        });
+    });
+
+    describe('mergeCollection pre-warm', () => {
+        // The retryOperation describe block above mutates StorageMock.setItem (and never restores it),
+        // so by the time we run, setItem may be a rejecting mock from a prior test. Capture pristine
+        // references at file-load time and restore them in beforeEach so our seeding via Onyx.set
+        // actually reaches the in-memory storage provider.
+        const pristineSetItem = StorageMock.setItem;
+        const pristineMultiSet = StorageMock.multiSet;
+        const pristineMultiGet = StorageMock.multiGet;
+        const pristineGetItem = StorageMock.getItem;
+        const pristineMultiMerge = StorageMock.multiMerge;
+
+        beforeEach(() => {
+            StorageMock.setItem = pristineSetItem;
+            StorageMock.multiSet = pristineMultiSet;
+            StorageMock.multiGet = pristineMultiGet;
+            StorageMock.getItem = pristineGetItem;
+            StorageMock.multiMerge = pristineMultiMerge;
+        });
+
+        // Make a key "cold" — value evicted from cache but the key is still tracked as persisted.
+        // OnyxCache.drop also removes the key from `storageKeys`, which would cause getAllKeys() to
+        // miss it (unless the entire storageKeys set is empty, in which case the function falls back
+        // to Storage.getAllKeys). To reliably hit the cold-but-persisted state regardless of how many
+        // other keys remain in cache, we re-register the key as known after dropping its value.
+        const evictFromCache = (...keys: string[]) =>
+            keys.forEach((key) => {
+                OnyxCache.drop(key);
+                OnyxCache.addKey(key);
+            });
+
+        it('fast path: skips storage reads entirely when every existing key is warm in cache', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const existingKey1 = `${collectionKey}1`;
+            const existingKey2 = `${collectionKey}2`;
+
+            // Seed both members so they are both warm in cache and present in storage.
+            await Onyx.set(existingKey1, {value: 'initial-1'});
+            await Onyx.set(existingKey2, {value: 'initial-2'});
+
+            const multiGetSpy = jest.spyOn(StorageMock, 'multiGet');
+            const getItemSpy = jest.spyOn(StorageMock, 'getItem');
+
+            await Onyx.mergeCollection(collectionKey, {
+                [existingKey1]: {value: 'merged-1'},
+                [existingKey2]: {value: 'merged-2'},
+            } as GenericCollection);
+
+            // With every existingKey warm, the diff swaps Promise.all(get) for Promise.resolve(),
+            // so no storage reads should happen during the pre-warm.
+            expect(multiGetSpy).not.toHaveBeenCalled();
+            expect(getItemSpy).not.toHaveBeenCalled();
+
+            // Cache still reflects the merge.
+            const cached = OnyxCache.getCollectionData(collectionKey);
+            expect(cached?.[existingKey1]).toEqual({value: 'merged-1'});
+            expect(cached?.[existingKey2]).toEqual({value: 'merged-2'});
+        });
+
+        it('slow path: batches cold existing keys into a single Storage.multiGet, with no individual getItem calls', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const coldKey1 = `${collectionKey}1`;
+            const coldKey2 = `${collectionKey}2`;
+            const warmKey = `${collectionKey}3`;
+
+            // Seed all three in storage, then evict two from cache so they are cold-but-persisted.
+            await Onyx.set(coldKey1, {value: 'persisted-1'});
+            await Onyx.set(coldKey2, {value: 'persisted-2'});
+            await Onyx.set(warmKey, {value: 'persisted-3'});
+            evictFromCache(coldKey1, coldKey2);
+
+            // Reset spies AFTER seeding so we only count calls made during mergeCollection itself.
+            const multiGetSpy = jest.spyOn(StorageMock, 'multiGet').mockClear();
+            const getItemSpy = jest.spyOn(StorageMock, 'getItem').mockClear();
+
+            await Onyx.mergeCollection(collectionKey, {
+                [coldKey1]: {value: 'merged-1'},
+                [coldKey2]: {value: 'merged-2'},
+                [warmKey]: {value: 'merged-3'},
+            } as GenericCollection);
+
+            // OnyxUtils.multiGet filters to cache-missing keys before issuing Storage.multiGet, so we
+            // expect exactly one batched read containing only the cold keys (the warm key is skipped).
+            expect(multiGetSpy).toHaveBeenCalledTimes(1);
+            const requestedKeys = multiGetSpy.mock.calls[0][0] as string[];
+            expect(requestedKeys.sort()).toEqual([coldKey1, coldKey2].sort());
+
+            // No individual Storage.getItem calls during pre-warm. Old code path would have fired one
+            // get() per existing key, each potentially landing in Storage.getItem on cache miss.
+            expect(getItemSpy).not.toHaveBeenCalled();
+        });
+
+        it('slow path: cold-cache merge layers the new delta on top of existing storage data (no field drops)', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const coldKey = `${collectionKey}1`;
+
+            // Seed an object with multiple fields in storage, then evict from cache so the merge base
+            // must come from a storage read — not from `undefined`.
+            await Onyx.set(coldKey, {a: 1, b: 2});
+            evictFromCache(coldKey);
+
+            await Onyx.mergeCollection(collectionKey, {
+                [coldKey]: {c: 3},
+            } as GenericCollection);
+
+            // If the pre-warm did NOT populate the cache from storage, fastMerge would treat the
+            // previous value as undefined and the result would drop {a:1, b:2}. With the pre-warm
+            // running multiGet on the cold key, the merge layers {c:3} on top of {a:1, b:2}.
+            const cached = OnyxCache.getCollectionData(collectionKey);
+            expect(cached?.[coldKey]).toEqual({a: 1, b: 2, c: 3});
+        });
+
+        it('warm cache: subscriber receives a single merged broadcast for an Onyx.update batch (no transient undefined)', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const existingKey = `${collectionKey}1`;
+
+            await Onyx.set(existingKey, {value: 'initial'});
+
+            const collectionCallback = jest.fn();
+            Onyx.connect({
+                key: collectionKey,
+                waitForCollectionCallback: true,
+                callback: collectionCallback,
+            });
+            await waitForPromisesToResolve();
+            collectionCallback.mockClear();
+
+            await Onyx.update([
+                {
+                    onyxMethod: Onyx.METHOD.MERGE_COLLECTION,
+                    key: collectionKey,
+                    value: {
+                        [existingKey]: {value: 'merged'},
+                    } as GenericCollection,
+                },
+            ]);
+
+            // The fast path resolves the pre-warm synchronously (Promise.resolve()), preserving the
+            // original promise-chain depth. The Onyx.update batch must therefore broadcast exactly
+            // one merged value — not undefined first and the merged value on a later microtask.
+            const broadcasts = collectionCallback.mock.calls.map((c) => c[0]);
+            expect(broadcasts).toHaveLength(1);
+            expect(broadcasts[0]?.[existingKey]).toEqual({value: 'merged'});
+        });
+
+        it('equivalence: warm-path and cold-path produce the same final cache state for the same merge', async () => {
+            const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;
+            const memberKey = `${collectionKey}1`;
+            const delta = {value: 'after'} as const;
+
+            // Warm-path run.
+            await Onyx.set(memberKey, {value: 'before', extra: 'kept'});
+            await Onyx.mergeCollection(collectionKey, {
+                [memberKey]: delta,
+            } as GenericCollection);
+            const warmResult = OnyxCache.getCollectionData(collectionKey)?.[memberKey];
+
+            // Reset and replay with a cold cache before the merge.
+            await Onyx.clear();
+            await Onyx.set(memberKey, {value: 'before', extra: 'kept'});
+            evictFromCache(memberKey);
+            await Onyx.mergeCollection(collectionKey, {
+                [memberKey]: delta,
+            } as GenericCollection);
+            const coldResult = OnyxCache.getCollectionData(collectionKey)?.[memberKey];
+
+            expect(warmResult).toEqual(coldResult);
+            expect(coldResult).toEqual({value: 'after', extra: 'kept'});
         });
     });
 
@@ -983,7 +1184,9 @@ describe('OnyxUtils', () => {
             // No more evictable candidates
             expect(LocalOnyxCache.getKeyForEviction()).toBeUndefined();
             // Non-evictable key should still be in cache
-            expect(LocalOnyxCache.get(ONYXKEYS.TEST_KEY)).toEqual({test: 'not evictable'});
+            expect(LocalOnyxCache.get(ONYXKEYS.TEST_KEY)).toEqual({
+                test: 'not evictable',
+            });
         });
 
         it('should not add collection keys to eviction candidates, only their members', async () => {
@@ -1009,8 +1212,12 @@ describe('OnyxUtils', () => {
             LocalOnyxCache = require('../../lib/OnyxCache').default;
             const storage = require('../../lib/storage').default;
 
-            await storage.setItem(`${ONYXKEYS.COLLECTION.TEST_KEY}pre1`, {id: 'pre1'});
-            await storage.setItem(`${ONYXKEYS.COLLECTION.TEST_KEY}pre2`, {id: 'pre2'});
+            await storage.setItem(`${ONYXKEYS.COLLECTION.TEST_KEY}pre1`, {
+                id: 'pre1',
+            });
+            await storage.setItem(`${ONYXKEYS.COLLECTION.TEST_KEY}pre2`, {
+                id: 'pre2',
+            });
 
             // Init — addEvictableKeysToRecentlyAccessedList should seed them
             LocalOnyx.init({

--- a/tests/unit/onyxUtilsTest.ts
+++ b/tests/unit/onyxUtilsTest.ts
@@ -954,11 +954,12 @@ describe('OnyxUtils', () => {
         // miss it (unless the entire storageKeys set is empty, in which case the function falls back
         // to Storage.getAllKeys). To reliably hit the cold-but-persisted state regardless of how many
         // other keys remain in cache, we re-register the key as known after dropping its value.
-        const evictFromCache = (...keys: string[]) =>
-            keys.forEach((key) => {
+        const evictFromCache = (...keys: string[]) => {
+            for (const key of keys) {
                 OnyxCache.drop(key);
                 OnyxCache.addKey(key);
-            });
+            }
+        };
 
         it('fast path: skips storage reads entirely when every existing key is warm in cache', async () => {
             const collectionKey = ONYXKEYS.COLLECTION.TEST_KEY;


### PR DESCRIPTION
### Details

Hybrid pre-warm strategy for `mergeCollectionWithPatches` that replaces the unconditional `Promise.all(existingKeys.map((key) => get(key)))`:

- **Fast path** (every `existingKey` is already warm in cache): use a sync-resolved `Promise.resolve()`. No extra microtask hops, preserving the original promise-chain depth and the subscriber-callback timing that dependent tests rely on (`Onyx.update` batch tests broadcast a single merged callback rather than `undefined` followed by the merged value).

- **Slow path** (at least one `existingKey` is a cache miss): use `multiGet`, which batches the missing keys into a single `Storage.multiGet` round-trip instead of N parallel `get()` invocations and writes the storage values back to cache before resolving.

Net result: same correctness as before, fewer storage operations on cold-cache merges, identical broadcast timing for warm-cache merges.

Addresses follow-up from Expensify/react-native-onyx#787 review.

### Related Issues

https://github.com/Expensify/App/issues/90634

### Automated Tests

Added a new `describe('mergeCollection pre-warm', ...)` block in `tests/unit/onyxUtilsTest.ts` with 5 tests:

1. **`fast path: skips storage reads entirely when every existing key is warm in cache`** — Seeds two members via `Onyx.set`, spies on `StorageMock.multiGet` and `StorageMock.getItem`, then runs `Onyx.mergeCollection`. Asserts both spies are called **0 times**. Confirms the diff's `Promise.resolve()` shortcut.

2. **`slow path: batches cold existing keys into a single Storage.multiGet, with no individual getItem calls`** — Seeds three members, evicts two from cache (cold), leaves one warm. Asserts `Storage.multiGet` is called **exactly once** with only the two cold keys (the warm key is filtered out by `OnyxUtils.multiGet`), and `Storage.getItem` is never called during pre-warm.

3. **`slow path: cold-cache merge layers the new delta on top of existing storage data (no field drops)`** — Seeds a key with `{a:1, b:2}` then evicts from cache. Merges `{c:3}` and asserts the cache holds `{a:1, b:2, c:3}`. Without the pre-warm reading from storage, `cache.merge` would start from `undefined` and drop `{a:1, b:2}` — this guards the correctness invariant the in-code comment specifically calls out.

4. **`warm cache: subscriber receives a single merged broadcast for an Onyx.update batch (no transient undefined)`** — Subscribes to a warm collection key, fires an `Onyx.update` with a `MERGE_COLLECTION` op. Asserts subscriber was called exactly once with the final merged value (NOT `undefined` then merged on a later microtask). Guards the promise-chain-depth invariant.

5. **`equivalence: warm-path and cold-path produce the same final cache state for the same merge`** — Runs the same effective merge against a warm cache and against a cold cache; asserts the post-merge collection state is identical in both runs.

**Suite-pollution fix:** the `retryOperation` describe block earlier in the file mutates `StorageMock.setItem` (and other methods) without restoring them. This block captures pristine references at file-load time and restores them in `beforeEach` so seeding via `Onyx.set` actually persists.

**Helper note:** `OnyxCache.drop` removes the key from `storageKeys`, which makes `getAllKeys()` miss it when other keys remain in cache. The `evictFromCache` helper calls `OnyxCache.addKey(key)` after `drop` so the key stays "tracked but unloaded" — exactly the cold-but-persisted state the slow path is meant to handle.

Local results:

- `npx jest` — **450/450** pass across 16 suites.
- `npx tsc --noEmit` — clean.

### Manual Tests

End-to-end verification against `Expensify/App` via the companion PR **Expensify/App#91585**, which pins `react-native-onyx`'s `package.json` to this branch's head SHA.

**Setup**

1. In the App repo, check out the companion branch that pins `react-native-onyx` to this PR's head SHA.
2. `npm install` under Node 20.20.0, then `npm run web`.
3. Open https://dev.new.expensify.com:8082/ in Chrome with DevTools open.
4. Sign in.


**Functional smoke (same flows as #787, expect no regression)**

For each: open the screen, perform the action, verify UI updates immediately, persist after reload.

1. Initial hydration after login — LHN populates correctly.
2. Send a chat message — appears immediately, confirms via Pusher, persists after reload.
3. Mark-all-as-read — badges clear and stay cleared.
4. Search filter — results populate and update live.
5. Hold / unhold an expense — badge toggles and persists.
6. Submit expense via FAB — appears in report immediately, persists.
7. Switch workspaces — LHN filters to new workspace.

**Cold-cache merge correctness**

1. Sign in and perform an action that writes collection data.
2. Reload (clears cache, keeps storage).
3. Trigger a `MERGE_COLLECTION` against one of those keys **before** the LHN hydrates it.
4. **Expected**: merged value retains all fields from storage; the new delta is layered on top — no silent drops. (Slow-path correctness.)

**Storage-failure regression (carry-over from #787)**

1. With App running and authenticated, Application → IndexedDB → right-click → delete `OnyxDB`. **Do not reload.**
2. Immediately trigger a `MERGE_COLLECTION` action.
3. **Expected**: UI updates correctly; new state is visible to subscribers even though the IDB write fails. Console shows storage errors, but no white screen / no stale UI / no data loss within the session.

### Author Checklist

- [x] I linked the correct issue in the `### Related Issues` section above
- [x] I wrote clear testing steps that cover the changes made in this PR
  - [x] I added steps for local testing in the `Tests` section
  - [x] I tested this PR with a [High Traffic account](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#high-traffic-accounts) against the staging or production API to ensure there are no regressions (e.g. long loading states that impact usability).
- [x] I included screenshots or videos for tests on [all platforms](https://github.com/Expensify/App/blob/main/contributingGuides/CONTRIBUTING.md#make-sure-you-can-test-on-all-platforms)
- [x] I ran the tests on **all platforms** & verified they passed on:
  - [x] Android / native
  - [x] Android / Chrome
  - [x] iOS / native
  - [x] iOS / Safari
  - [x] MacOS / Chrome / Safari
- [x] I verified there are no console errors (if there's a console error not related to the PR, report it or open an issue for it to be fixed)
- [x] I followed proper code patterns (see [Reviewing the code](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md#reviewing-the-code))
  - [x] I verified that any callback methods that were added or modified are named for what the method does and never what callback they handle (i.e. `toggleReport` and not `onIconClick`)
  - [x] I verified that the left part of a conditional rendering a React component is a boolean and NOT a string, e.g. `myBool && <MyComponent />`.
  - [x] I verified that comments were added to code that is not self explanatory
  - [x] I verified that any new or modified comments were clear, correct English, and explained "why" the code was doing something instead of only explaining "what" the code was doing.
  - [x] I verified proper file naming conventions were followed for any new files or renamed files. All non-platform specific files are named after what they export and are not named "index.js". All platform-specific files are named for the platform the code supports as outlined in the README.
  - [x] I verified the JSDocs style guidelines (in [`STYLE.md`](https://github.com/Expensify/App/blob/main/contributingGuides/STYLE.md#jsdocs)) were followed
- [x] If a new code pattern is added I verified it was agreed to be used by multiple Expensify engineers
- [x] I followed the guidelines as stated in the [Review Guidelines](https://github.com/Expensify/App/blob/main/contributingGuides/PR_REVIEW_GUIDELINES.md)
- [x] I tested other components that can be impacted by my changes (i.e. if the PR modifies a shared library or component like `Avatar`, I verified the components using `Avatar` are working as expected)
- [x] I verified all code is DRY (the PR doesn't include any logic written more than once, with the exception of tests)
- [x] I verified any variables that can be defined as constants (ie. in CONST.js or at the top of the file that uses the constant) are defined as such
- [x] I verified that if a function's arguments changed that all usages have also been updated correctly
- [x] If a new component is created I verified that:
  - [x] A similar component doesn't exist in the codebase
  - [x] All props are defined accurately and each prop has a `/** comment above it */`
  - [x] The file is named correctly
  - [x] The component has a clear name that is non-ambiguous and the purpose of the component can be inferred from the name alone
  - [x] The only data being stored in the state is data necessary for rendering and nothing else
  - [x] If we are not using the full Onyx data that we loaded, I've added the proper selector in order to ensure the component only re-renders when the data it is using changes
  - [x] For Class Components, any internal methods passed to components event handlers are bound to `this` properly so there are no scoping issues (i.e. for `onClick={this.submit}` the method `this.submit` should be bound to `this` in the constructor)
  - [x] Any internal methods bound to `this` are necessary to be bound (i.e. avoid `this.submit = this.submit.bind(this);` if `this.submit` is never passed to a component event handler like `onClick`)
  - [x] All JSX used for rendering exists in the render method
  - [x] The component has the minimum amount of code necessary for its purpose, and it is broken down into smaller components in order to separate concerns and functions
- [x] If any new file was added I verified that:
  - [x] The file has a description of what it does and/or why is needed at the top of the file if the code is not self explanatory
- [x] If the PR modifies a generic component, I tested and verified that those changes do not break usages of that component in the rest of the App (i.e. if a shared library or component like `Avatar` is modified, I verified that `Avatar` is working as expected in all cases)
- [x] If the `main` branch was merged into this PR after a review, I tested again and verified the outcome was still expected according to the `Test` steps.
- [x] I have checked off every checkbox in the PR author checklist, including those that don't apply to this PR.

### Screenshots/Videos

<details>
<summary>Android: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>Android: mWeb Chrome</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: Native</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>iOS: mWeb Safari</summary>

<!-- add screenshots or videos here -->

</details>

<details>
<summary>MacOS: Chrome / Safari</summary>




https://github.com/user-attachments/assets/07611d7d-4c0b-488d-a440-25cbd39d8cae


https://github.com/user-attachments/assets/28948810-6417-4da1-8182-be21f1b2b863


https://github.com/user-attachments/assets/49d5e79f-e7f8-4476-9c38-4669d42f2383


https://github.com/user-attachments/assets/9c743510-d5a7-412e-9986-6fa577a36532

<img width="1512" height="776" alt="Screenshot 2026-05-25 at 12 25 01" src="https://github.com/user-attachments/assets/7f1c1339-b384-4ecc-8d23-f0d501d8b0ab" />







</details>
